### PR TITLE
Fixed Blog Content error when exceeding 50 words

### DIFF
--- a/src/main/java/com/insights/blog/model/Blog.java
+++ b/src/main/java/com/insights/blog/model/Blog.java
@@ -41,7 +41,8 @@ public class Blog {
 
     private String title;
 
-    @Column(columnDefinition = "MEDIUMTEXT")
+//    @Column(columnDefinition = "MEDIUMTEXT")
+    @Column(length=6969)
     private String content;
 
     @CreatedDate


### PR DESCRIPTION
fixed the "Data truncation: Data too long for column 'content' at row 1" error